### PR TITLE
axi dma: fix DA_MSB and SA_MSB calculation in 32 bit platforms

### DIFF
--- a/src/axi_dma.rs
+++ b/src/axi_dma.rs
@@ -74,7 +74,7 @@ impl AxiDma {
             // Configure AXIDMA - MM2S (PS -> PL)
             ptr::write_volatile(self.base.offset(MM2S_DMACR), 0x7001);
             ptr::write_volatile(self.base.offset(MM2S_SA), (buff.phys_addr() & 0xffff_ffff) as u32);
-            ptr::write_volatile(self.base.offset(MM2S_SA_MSB), (buff.phys_addr() >> 32) as u32);
+            ptr::write_volatile(self.base.offset(MM2S_SA_MSB), buff.phys_addr().wrapping_shr(32) as u32);
             ptr::write_volatile(self.base.offset(MM2S_LENGTH), bytes as u32);
         }
         Ok(())
@@ -92,7 +92,7 @@ impl AxiDma {
             // Configure AXIDMA - S2MM (PL -> PS)
             ptr::write_volatile(self.base.offset(S2MM_DMACR), 0x7001);
             ptr::write_volatile(self.base.offset(S2MM_DA), (buff.phys_addr() & 0xffff_ffff) as u32);
-            ptr::write_volatile(self.base.offset(S2MM_DA_MSB), (buff.phys_addr() >> 32) as u32);
+            ptr::write_volatile(self.base.offset(S2MM_DA_MSB), buff.phys_addr().wrapping_shr(32) as u32);
             ptr::write_volatile(self.base.offset(S2MM_LENGTH), bytes as u32);
         }
         Ok(())


### PR DESCRIPTION
Thanks for this crate! I'm using it on a 7000 series Zynq, which has a 32-bit processor, and have found that the `>> 32` shift to compute the 32 MSBs of the source/destination address panics. Replacing this by `.wrapping_shr(32)` gives the expected behaviour of writing zeros to 32 MSBs.