### PR TITLE
Add DMB memory barrier to H2D transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ async-io = "1.3.1"
 
 [dev-dependencies]
 fastrand = "1.4.0"
+
+[build-dependencies]
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .file("dmb.c")
+        // Overrride -march=armv6 coming from cross,
+        // since it gives the error:
+        // selected processor does not support `dmb sy' in ARM mode
+        .flag("-march=armv7-a")
+        .compile("dmb");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,21 @@
+use std::env;
+
 fn main() {
-    cc::Build::new()
-        .file("dmb.c")
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("Env variable CARGO_CFG_TARGET_ARCH not found");
+    
+    if arch != "arm" && arch != "aarch64" {
+        // dmb is only available in ARM
+        return;
+    }
+    
+    let mut build = cc::Build::new();
+    build.file("dmb.c");
+    if arch == "arm" {
         // Overrride -march=armv6 coming from cross,
         // since it gives the error:
         // selected processor does not support `dmb sy' in ARM mode
-        .flag("-march=armv7-a")
-        .compile("dmb");
+        build.flag("-march=armv7-a");
+    }
+    build.compile("dmb");
 }

--- a/dmb.c
+++ b/dmb.c
@@ -1,0 +1,3 @@
+void dmb() {
+	asm ("dmb sy" : : : "memory");
+}

--- a/src/axi_dma.rs
+++ b/src/axi_dma.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::ptr;
 
 use crate::DmaBuffer;
+use crate::dmb::dmb;
 
 const MM2S_DMACR:  isize = 0x0  / 4;
 const MM2S_DMASR:  isize = 0x4  / 4;
@@ -19,10 +20,6 @@ const S2MM_DA:     isize = 0x48 / 4;
 const S2MM_DA_MSB: isize = 0x4C / 4;
 const S2MM_LENGTH: isize = 0x58 / 4;
 
-#[link(name = "dmb")]
-extern "C" {
-    fn dmb();
-}
 
 pub struct AxiDma {
     dev: String,

--- a/src/axi_dma.rs
+++ b/src/axi_dma.rs
@@ -19,6 +19,11 @@ const S2MM_DA:     isize = 0x48 / 4;
 const S2MM_DA_MSB: isize = 0x4C / 4;
 const S2MM_LENGTH: isize = 0x58 / 4;
 
+#[link(name = "dmb")]
+extern "C" {
+    fn dmb();
+}
+
 pub struct AxiDma {
     dev: String,
     dev_fd: File,
@@ -65,6 +70,9 @@ impl AxiDma {
     pub fn start_h2d(&mut self, buff: &DmaBuffer, bytes: usize) -> Result<()> {
         debug_assert!(buff.size() >= bytes);
         unsafe {
+            // Ensure that the DDR buffer has been written to
+            dmb();
+
             // clear irqs in dma
             ptr::write_volatile(self.base.offset(MM2S_DMASR), 0x7000);
 

--- a/src/axi_dma_async.rs
+++ b/src/axi_dma_async.rs
@@ -8,6 +8,7 @@ use std::ptr;
 use async_io::Async;
 
 use crate::DmaBuffer;
+use crate::dmb::dmb;
 
 const MM2S_DMACR:  isize = 0x0  / 4;
 const MM2S_DMASR:  isize = 0x4  / 4;
@@ -20,10 +21,6 @@ const S2MM_DA:     isize = 0x48 / 4;
 const S2MM_DA_MSB: isize = 0x4C / 4;
 const S2MM_LENGTH: isize = 0x58 / 4;
 
-#[link(name = "dmb")]
-extern "C" {
-    fn dmb();
-}
 
 pub struct AxiDmaAsync {
     dev: String,

--- a/src/axi_dma_async.rs
+++ b/src/axi_dma_async.rs
@@ -20,6 +20,11 @@ const S2MM_DA:     isize = 0x48 / 4;
 const S2MM_DA_MSB: isize = 0x4C / 4;
 const S2MM_LENGTH: isize = 0x58 / 4;
 
+#[link(name = "dmb")]
+extern "C" {
+    fn dmb();
+}
+
 pub struct AxiDmaAsync {
     dev: String,
     dev_fd: Async<File>,
@@ -66,6 +71,9 @@ impl AxiDmaAsync {
     pub async fn start_h2d(&mut self, buff: &DmaBuffer, bytes: usize) -> Result<()> {
         debug_assert!(buff.size() >= bytes);
         unsafe {
+            // Ensure that the DDR buffer has been written to
+            dmb();
+
             // clear irqs in dma
             ptr::write_volatile(self.base.offset(MM2S_DMASR), 0x7000);
 

--- a/src/dmb.rs
+++ b/src/dmb.rs
@@ -1,0 +1,10 @@
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[link(name = "dmb")]
+extern "C" {
+    pub fn dmb();
+}
+
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+pub fn dmb() {
+    // DMB is ARM-only, so we use a nop in other archs
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod axi_dma;
 mod axi_dma_async;
 mod dma_buffer;
+mod dmb;
 pub use axi_dma::AxiDma;
 pub use axi_dma_async::AxiDmaAsync;
 pub use dma_buffer::DmaBuffer;


### PR DESCRIPTION
I still haven't tested this on hardware, so I'm marking it as a draft.

The generated code looks quite reasonable. Here is the relevant code compiled with `--release`:
```
000077b4 <xilinx_dma::axi_dma::AxiDma::start_h2d>:
    77b4:       e92d4070        push    {r4, r5, r6, lr}
    77b8:       e24dd010        sub     sp, sp, #16
    77bc:       e1a04002        mov     r4, r2
    77c0:       e1a06001        mov     r6, r1
    77c4:       e1a05000        mov     r5, r0
    77c8:       eb000934        bl      9ca0 <dmb>
    77cc:       e5950010        ldr     r0, [r5, #16]
    77d0:       e3a01a07        mov     r1, #28672      ; 0x7000
    77d4:       e59f2068        ldr     r2, [pc, #104]  ; 7844 <xilinx_dma::axi_dma::AxiDma::start_h2d+0x90>
    77d8:       e3a03004        mov     r3, #4
    77dc:       e5801004        str     r1, [r0, #4]
    77e0:       e08f2002        add     r2, pc, r2
    77e4:       e285100c        add     r1, r5, #12
    77e8:       e28d0004        add     r0, sp, #4
    77ec:       eb0050e9        bl      1bb98 <std::os::imp::unix::net::datagram::UnixDatagram::send>
    77f0:       e59d0004        ldr     r0, [sp, #4]
    77f4:       e3500001        cmp     r0, #1
    77f8:       15950010        ldrne   r0, [r5, #16]
    77fc:       13a01001        movne   r1, #1
    7800:       13811a07        orrne   r1, r1, #28672  ; 0x7000
    7804:       15801000        strne   r1, [r0]
    7808:       15950010        ldrne   r0, [r5, #16]
    780c:       15961010        ldrne   r1, [r6, #16]
    7810:       15801018        strne   r1, [r0, #24]
    7814:       15950010        ldrne   r0, [r5, #16]
    7818:       1580101c        strne   r1, [r0, #28]
    781c:       15950010        ldrne   r0, [r5, #16]
    7820:       15804028        strne   r4, [r0, #40]   ; 0x28
    7824:       13a00000        movne   r0, #0
    7828:       128dd010        addne   sp, sp, #16
    782c:       18bd8070        popne   {r4, r5, r6, pc}
    7830:       e59d0008        ldr     r0, [sp, #8]
    7834:       e59d100c        ldr     r1, [sp, #12]
    7838:       e28dd010        add     sp, sp, #16
    783c:       e8bd4070        pop     {r4, r5, r6, lr}
    7840:       eaffeced        b       2bfc <_ZN6anyhow5error31_$LT$impl$u20$anyhow..Error$GT$9construct17h3ef8ffe2f55ddd09E.llvm.18047369102374268922>
    7844:       0003712e        .word   0x0003712e

00009ca0 <dmb>:
    9ca0:       f57ff05f        dmb     sy
    9ca4:       e12fff1e        bx      lr
```

I think that the overhead of the function call is an acceptable prize to pay for the simplicity of this solution.