### PR TITLE
Add size_d2h() method to get packet size

### DIFF
--- a/src/axi_dma.rs
+++ b/src/axi_dma.rs
@@ -307,6 +307,10 @@ impl AxiDma {
         self.dev_fd.read_exact(&mut buf)?;
         Ok(())
     }
+
+    pub fn size_d2h(&self) -> usize {
+        unsafe { ptr::read_volatile(self.base.offset(S2MM_LENGTH)) as usize }
+    }
 }
 
 impl Drop for AxiDma {

--- a/src/axi_dma_async.rs
+++ b/src/axi_dma_async.rs
@@ -312,6 +312,10 @@ impl AxiDmaAsync {
         self.dev_fd.read_with_mut(|s| s.read(&mut buf)).await?;
         Ok(())
     }
+
+    pub fn size_d2h(&self) -> usize {
+        unsafe { ptr::read_volatile(self.base.offset(S2MM_LENGTH)) as usize }
+    }
 }
 
 impl Drop for AxiDmaAsync {


### PR DESCRIPTION
This adds a method `size_d2h()` that can be used to get the number of bytes that have been transferred in a device-to-host transfer. This corresponds to the size of the AXI-Stream packet that the AXI DMA has moved to RAM.

It is useful in a context where the size of the packets is controlled by the FPGA and the software doesn't know it in advance (I have a use case like this).

*More details (commit message):*

According to the AXI DMA documentation, the S2MM_LENGTH register (which corresponds directly to the bytes parameter of the start_d2h() method) is used to indicate the length in bytes of the buffer used to hold the data to be transferred. However, the data is an AXI-Stream packet, so its size comes determined by the TLAST line. Therefore, the actual size of the transferred data may be smaller than the buffer size. After completion of the transfer, the S2MM_LENGTH register is updated
with the actual number of bytes that have been transferred.

Thus, the user can call start_d2h() with the size of the buffer, then call wait_d2h(), and afterwards call size_d2h() to obtain the length of the data that has been transferred.

Note that the behaviour of the AXI DMA is undefined if the buffer is not large enough to hold the AXI-Stream packet, so the user should ensure that the buffer is large enough to hold any possible AXI-Stream packet that the AXI DMA might receive on its S_AXIS_S2MM port.