### PR TITLE
Add a feature flag to put all the async code behind it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ default = ["async"]
 async = ["async-io"]
 
 [dependencies]
-libc = "0.2.82"
-anyhow = "1.0.38"
+libc = "0.2"
+anyhow = "1.0"
 async-io = { version = "1.3.1", optional = true }
 
 [dev-dependencies]
-fastrand = "1.4.0"
+fastrand = "2.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ description = "Userspace Xilinx AXI DMA Interface"
 keywords = ["sdr", "dsp", "real-time", "async", "acceleration"]
 categories = ["asynchronous", "concurrency", "hardware-support", "science"]
 
+[features]
+default = ["async"]
+async = ["async-io"]
+
 [dependencies]
 libc = "0.2.82"
 anyhow = "1.0.38"
-async-io = "1.3.1"
+async-io = { version = "1.3.1", optional = true }
 
 [dev-dependencies]
 fastrand = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 mod axi_dma;
+
+#[cfg(feature = "async")]
 mod axi_dma_async;
+
 mod dma_buffer;
 pub use axi_dma::AxiDma;
+
+#[cfg(feature = "async")]
 pub use axi_dma_async::AxiDmaAsync;
+
 pub use dma_buffer::DmaBuffer;
 
 #[cfg(xilinx_dma_has_dmb)]


### PR DESCRIPTION
This adds a feature flag (enabled by default) `async` such that the async implementation will only be built when the feature is enabled. This allows projects that do not use the async implementation to avoid depending on the `async-io` crate.

I have also updated the dependencies of the project in a separate commit (these updates do not need any code changes).