### PR TITLE
axi_dma: fix MSB calculation in 32 bit platforms

### DIFF
--- a/src/axi_dma.rs
+++ b/src/axi_dma.rs
@@ -95,7 +95,7 @@ impl AxiDma {
             );
             ptr::write_volatile(
                 self.base.offset(MM2S_SA_MSB),
-                buff.phys_addr().wrapping_shr(32) as u32,
+                (buff.phys_addr() & !0xffff_ffff).wrapping_shr(32) as u32,
             );
             ptr::write_volatile(self.base.offset(MM2S_LENGTH), bytes as u32);
         }
@@ -120,7 +120,7 @@ impl AxiDma {
             );
             ptr::write_volatile(
                 self.base.offset(S2MM_DA_MSB),
-                buff.phys_addr().wrapping_shr(32) as u32,
+                (buff.phys_addr() & !0xffff_ffff).wrapping_shr(32) as u32,
             );
             ptr::write_volatile(self.base.offset(S2MM_LENGTH), bytes as u32);
         }

--- a/src/axi_dma_async.rs
+++ b/src/axi_dma_async.rs
@@ -98,7 +98,7 @@ impl AxiDmaAsync {
             );
             ptr::write_volatile(
                 self.base.offset(MM2S_SA_MSB),
-                buff.phys_addr().wrapping_shr(32) as u32,
+                (buff.phys_addr() & !0xffff_ffff).wrapping_shr(32) as u32,
             );
             ptr::write_volatile(self.base.offset(MM2S_LENGTH), bytes as u32);
         }
@@ -125,7 +125,7 @@ impl AxiDmaAsync {
             );
             ptr::write_volatile(
                 self.base.offset(S2MM_DA_MSB),
-                buff.phys_addr().wrapping_shr(32) as u32,
+                (buff.phys_addr() & !0xffff_ffff).wrapping_shr(32) as u32,
             );
             ptr::write_volatile(self.base.offset(S2MM_LENGTH), bytes as u32);
         }


### PR DESCRIPTION
In dca258daa2d7b80cff9f6e712d0ecf9d791aa2f2 and 6fbbf5c417f11d2baaa6bcd2061bc37f39a3361e, a panic that was produced when calculating the MSB address register on a 32 bit platform was fixed. However, the fix was not correct. It was intended that if `address: usize`, then `address.wrapping_shr(32)` would give 0 when `usize == u32`. However, this is not the case, since the operation performs no shift at all.

The correct way to obtain the MSB of the address in a way that works correctly both when `usize == u32` and when `usize == u64` is `(address & !0xffff_ffff).wrapping_shr(32)`. This gives 0 when `usize == u32` and the 32 MSBs when usize == u64.

The only reason that the incorrect code worked is because when the AXI DMA is configured to use 32 bit addresses, it ignores the contents of the MSB register.