### PR TITLE
Add wait timeout to sync AxiDma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ required-features = ["scatter-gather"]
 [features]
 default = []
 async = ["dep:async-io"]
+timeout = ["dep:polling"]
 scatter-gather = []
 
 [dependencies]
 async-io = { version = "2.2", optional = true }
 libc = "0.2"
+polling = { version = "3.11", optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,4 +47,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Failed to parse integer from sysfs files.")]
     Parse(#[from] std::num::ParseIntError),
+    #[cfg(feature = "timeout")]
+    #[error("Timeout reached")]
+    Timeout,
 }


### PR DESCRIPTION
This adds `wait_d2h_timeout` and `wait_h2d_timeout` methods to `AxiDma`. These methods wait for an interrupt to be received until a timeout is reached. If the timeout is reached without an interrupt being received, then the method returns `Error::Timeout`. If an interrupt is received, then the method returns `Ok(())`.

The crate `polling` is used as a portable way to use `epoll` on the UIO file descriptor to check if it is ready for reading (however note that UIO is Linux only, so portability is not an important need here).

All these changes are gated behind a feature called `"timeout"`, so that code that does not need to use these timeouts does not need to bring in `polling` as a dependency.

---

I have only added a timeout to the sync `AxiDma`. For the async `AxiDmaAsync` I think there are other possible ways to wait with a timeout (for instance using `select!` to wait either for the interrupt or a future that completes after a given timeout, which is basically what Tokio's [timeout](https://docs.rs/tokio/latest/tokio/time/fn.timeout.html) does). Let me know if this approach sounds reasonable.

---

**Testing**

I am using this in a project in which I need to receive a few packets with a d2h AXI-DMA but I don't know what many packets there are in advance. So I call `start_d2h()` and `wait_d2h_timeout(Duration::from_secs(1))` in a loop until this returns a timeout error. This implementation of `wait_d2h_timeout` works fine in my project.